### PR TITLE
Appdata patch

### DIFF
--- a/org.sparkleshare.SparkleShare.appdata.xml
+++ b/org.sparkleshare.SparkleShare.appdata.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <name>SparkleShare</name>
+    <summary>Magic self hosted Git file sync</summary>
+    <developer_name>Hylke Bons</developer_name>
+    <project_license>GPL-3.0+</project_license>
+    <url type="homepage">http://www.sparkleshare.org/</url>
+    <url type="bugtracker">https://www.github.com/hbons/SparkleShare/issues</url>
+    
+    <description>
+        <p>SparkleShare is a file sharing and collaboration app. It works just like Dropbox, and you can run it on your own server.</p>
+        <p>SparkleShare is based on the popular version control system Git. It even supports the popular extension Git LFS to deal well with large files. So if you are already using Git repositories in your company, SparkleShare will integrate seamlessly.</p>
+        <p>Note: on some Linux distributions you'll need the TopIcons extension for GNOME Shell to show the SparkleShare status icon.</p>
+    </description>
+
+    <releases>
+        <release version="2.0.1" date="2017-12-04" urgency="low">
+            <description>
+                <p>Fixes and improvements:</p>
+                <ul>
+                    <li>Fix files created by conflict resolution being moved to the root folder</li>
+                    <li>On conflicts, both diverging versions plus the original version are now kept</li>
+                </ul>
+           </description>
+        </release>
+        <release version="2.0.0" date="2017-09-10" urgency="medium">
+            <description>
+                <p>SparkleShare 2.0 is a clean break and will be incompatible with the 1.x series. Repositories added using 1.0 will likely not work and will have to be re-synced to take advantage of 2.0 features (1.x and 2.x clients will still be able to sync to the same repository without problems).</p>
+                <ul>
+                    <li>Support for Git LFS managed repositories</li>
+                    <li>Projects are now grouped by host or organisation</li>
+                    <li>In encrypted repositories, name and email metadata is now also encrypted</li>
+                    <li>Change notification preferences from GNOME System Settings</li>
+                    <li>New GitLab preset</li>
+                    <li>New app icon by Sam Hewitt</li>
+                </ul>
+           </description>
+       </release>
+    </releases>  
+
+    <screenshots>
+        <screenshot type="default">
+            <caption>Sync projects to your computer</caption>
+            <image type="source" width="1338" height="754">https://raw.githubusercontent.com/hbons/SparkleShare/master/SparkleShare/Linux/Images/gnome-software-screenshot-1.png</image>
+        </screenshot>
+        <screenshot>
+            <caption>View your team's file history</caption>
+            <image type="source" width="1338" height="754">https://raw.githubusercontent.com/hbons/SparkleShare/master/SparkleShare/Linux/Images/gnome-software-screenshot-2.png</image>
+        </screenshot>
+    </screenshots>
+
+    <id type="desktop">org.sparkleshare.SparkleShare.desktop</id>
+    <launchable id="desktop-id">org.sparkleshare.SparkleShare.desktop</launchable>
+    <provides>
+        <binary>sparkleshare</binary>
+    </provides>
+    
+    <metadata_licence>CC0-1.0</metadata_licence>
+    <update_contact>hi_AT_planetpeanut.uk</update_contact>
+</component>

--- a/org.sparkleshare.SparkleShare.json
+++ b/org.sparkleshare.SparkleShare.json
@@ -123,11 +123,15 @@
                     "type": "archive",
                     "url": "https://github.com/hbons/SparkleShare/archive/2.0.1.tar.gz",
                     "sha256": "8d7ceaf3aadaea1f8715aa6175cf4dd3353824f0975b9861eed5e732552ab840"
+                },
+                {
+                    "type": "file",
+                    "path": "org.sparkleshare.SparkleShare.appdata.xml"
                 }
             ],
             "post-install": [
                 "mkdir /app/share/appdata/",
-                "cp SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml /app/share/appdata/"
+                "cp org.sparkleshare.SparkleShare.appdata.xml /app/share/appdata/"
             ]
         }
     ]


### PR DESCRIPTION
SparkleShare has a much better appdata file on the master branch than is available in the current 2.0.1 release:

https://github.com/hbons/SparkleShare/blob/master/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml

This brings that appdata into the flathub version until a new release happens, whereupon it should be dropped. 