### PR TITLE
Mark SparkleShare as EOL

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,49 @@
+From b47498f0a756748c709cd8668c8cf50e8432af49 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Thu, 18 Dec 2025 21:26:03 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml b/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
+index 2742669..82e0baf 100644
+--- a/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
++++ b/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
+@@ -1,9 +1,12 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<component type="desktop">
++<component type="desktop-application">
++    <id>org.sparkleshare.SparkleShare</id>
+     <name>SparkleShare</name>
++    <project_license>GPL-3.0+</project_license>
++    <metadata_license>CC0-1.0</metadata_license>
++    <launchable type="desktop-id">org.sparkleshare.SparkleShare.desktop</launchable>
+     <summary>Magic self hosted Git file sync</summary>
+     <developer_name>Hylke Bons</developer_name>
+-    <project_license>GPL-3.0+</project_license>
+     <url type="homepage">http://www.sparkleshare.org/</url>
+     <url type="bugtracker">https://www.github.com/hbons/SparkleShare/issues</url>
+     
+@@ -62,12 +65,13 @@
+         </screenshot>
+     </screenshots>
+ 
+-    <id type="desktop">org.sparkleshare.SparkleShare.desktop</id>
+-    <launchable id="desktop-id">org.sparkleshare.SparkleShare.desktop</launchable>
+     <provides>
+         <binary>sparkleshare</binary>
++        <id>org.sparkleshare.SparkleShare.desktop</id>
+     </provides>
+-    
+-    <metadata_licence>CC0-1.0</metadata_licence>
++    <replaces>
++        <id>org.sparkleshare.SparkleShare.desktop</id>
++    </replaces>
++    <content_rating type="oars-1.1" />
+     <update_contact>hi_AT_planetpeanut.uk</update_contact>
+ </component>
+--
+libgit2 1.7.2
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "This application is no longer maintained."
 }
-

--- a/org.sparkleshare.SparkleShare.yml
+++ b/org.sparkleshare.SparkleShare.yml
@@ -99,9 +99,11 @@ modules:
       no-parallel-make: true
 
     - name: sparkleshare
+      buildsystem: meson
       sources:
           - type: archive
             url: 'https://github.com/hbons/SparkleShare/archive/3.28.tar.gz'
             sha256: a52d6eab102411da5b6c772c8446c8ea95885c1f87de30dab9782011a449222f
-      buildsystem: meson
+          - type: patch
+            path: fix_appdata.patch
 

--- a/org.sparkleshare.SparkleShare.yml
+++ b/org.sparkleshare.SparkleShare.yml
@@ -11,8 +11,8 @@ finish-args:
     - --share=network
     - --socket=wayland
     - --socket=x11
-    - --talk-name=org.gtk.vfs
     - --talk-name=org.gtk.vfs.*
+    - --filesystem=xdg-run/gvfsd
     - --talk-name=org.freedesktop.Notifications
     - --talk-name=com.canonical.indicator.application
     - --talk-name=org.kde.StatusNotifierWatcher

--- a/org.sparkleshare.SparkleShare.yml
+++ b/org.sparkleshare.SparkleShare.yml
@@ -10,7 +10,7 @@ finish-args:
     - --share=ipc
     - --share=network
     - --socket=wayland
-    - --socket=x11
+    - --socket=fallback-x11
     - --talk-name=org.gtk.vfs.*
     - --filesystem=xdg-run/gvfsd
     - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
SparkleShare is the only application still using org.gnome.Platform 3.28.

It also hasn't been maintained for many years.

See: https://github.com/flathub/org.sparkleshare.SparkleShare/issues/8#issuecomment-2447867033